### PR TITLE
Fix wrong price/unit pairing in some SPAR items

### DIFF
--- a/analysis.js
+++ b/analysis.js
@@ -21,13 +21,24 @@ function sparToCanonical(rawItems, today) {
     const canonicalItems = [];
     for (let i = 0; i < rawItems.length; i++) {
         const item = rawItems[i];
+
+        let price, unit;
+        if (item.masterValues["quantity-selector"]) {
+            const [str_price, str_unit] = item.masterValues["price-per-unit"].split('/');
+            price = parseFloat(str_price.replace("€", ""));
+            unit = str_unit.trim();
+        }
+        else {
+            price = item.masterValues.price;
+            unit = item.masterValues["short-description-3"];
+        }
         canonicalItems.push({
             store: "spar",
             id: item.masterValues["code-internal"],
             name: item.masterValues.title + " " + item.masterValues["short-description"],
-            price: item.masterValues.price,
-            priceHistory: [{ date: today, price: item.masterValues.price }],
-            unit: item.masterValues["short-description-3"]
+            price,
+            priceHistory: [{ date: today, price }],
+            unit
         });
     }
     return canonicalItems;


### PR DESCRIPTION
Some Spar articles (I assume the ones in "Bedienung") have wrong price or unit. See this one for example: https://www.interspar.at/shop/lebensmittel/search/?q=Woerle%20Emmentaler%20aus%20Sommermilch
It's listed as 1.19 per 1KG (I have to say, also the interspar website is a bit misleading).

Proposed fix: Use 'price-per-unit' if the 'quantity-selector' field is available. (This field is available in about 500 articles and seems appropriate, but I didn't do any further testing/comparison).

Before: 
![buggy](https://github.com/badlogic/heissepreise/assets/10582844/786e80b7-52a9-4e20-a01e-46925c5de294)

After:
![fixed](https://github.com/badlogic/heissepreise/assets/10582844/b63cdf2e-907c-4ffc-bd0c-d81e9b0c6419)

I would keep the difference "1 KG" vs "kg", this way you recognize this is a weighted article :)