### PR TITLE
Allow custom port on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Merged price history
 Example app listening on port 3000
 ```
 
-Once the app is listening on port 3000, open http://localhost:3000 in your browser.
+Once the app is listening per default on port 3000, open http://localhost:3000 in your browser.\
+**Note**: If you want to start on a different port add it as the third parameter, e.g. `node index.js 3001` will map to port `3001`.
 
 Subsequent starts will fetch the data asynchronously, so you can start working immediately.
 

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ let itemsJson = "";
   const express = require('express')
   const compression = require('compression');
   const app = express()
-  const port = 3000
+  const port = process?.argv?.[2] ?? 3000
 
   app.use(express.static('site'));
   app.use(compression());


### PR DESCRIPTION
Allow users to diverge from default port 3000, e.g. if this port is already taken.