### PR TITLE
fix: :bug: add missing data dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 node_modules
 docker/data
 .DS_Store
-data/
 dist
 heissepreise.zip

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
After git-clone you would need to manually create the `data` directory, else it will not work as the first fetch complains that the files are not present. 

We could also fix it on the fetch data logic, but this would be an easy solution. 