### PR TITLE
Refactor UI to generic store syntax

### DIFF
--- a/stores/billa.js
+++ b/stores/billa.js
@@ -8,7 +8,8 @@ exports.getCanonical = function(item, today) {
         price: item.data.price.final,
         priceHistory: [{ date: today, price: item.data.price.final }],
         unit: item.data.grammagePriceFactor == 1 ? item.data.grammage : "kg",
-        bio: item.data.attributes && item.data.attributes.includes("s_bio")
+        bio: item.data.attributes && item.data.attributes.includes("s_bio"),
+        url: `https://shop.billa.at${item.data.canonicalPath}`
     };
 }
 

--- a/stores/dm.js
+++ b/stores/dm.js
@@ -8,6 +8,7 @@ exports.getCanonical = function(item, today) {
         priceHistory: [{ date: today, price: item.price.value }],
         unit: `${item.netQuantityContent} ${item.contentUnit}`,
         ...(item.brandName === "dmBio" || (item.name ? (item.name.startsWith("Bio ") | item.name.startsWith("Bio-")) : false)) && {bio: true},
+        url: `https://www.dm.at/product-p${item.gtin}.html`
     };
 }
 

--- a/stores/hofer.js
+++ b/stores/hofer.js
@@ -7,7 +7,8 @@ exports.getCanonical = function(item, today) {
         price: item.Price,
         priceHistory: [{ date: today, price: item.Price }],
         unit: `${item.Unit} ${item.UnitType}`,
-        bio: item.IsBio
+        bio: item.IsBio,
+        url: `https://www.roksh.at/hofer/produkte/${item.CategorySEOName}/${item.SEOName}`
     };
 }
 

--- a/stores/lidl.js
+++ b/stores/lidl.js
@@ -8,7 +8,7 @@ exports.getCanonical = function(item, today) {
         price: item.price.price,
         priceHistory: [{ date: today, price: item.price.price }],
         unit: item.price.basePrice?.text ?? "",
-        url: item.canonicalUrl
+        url: `https://www.lidl.at${item.canonicalUrl}`
     };
 }
 

--- a/stores/mpreis.js
+++ b/stores/mpreis.js
@@ -7,7 +7,8 @@ exports.getCanonical = function(item, today) {
         price: item.prices[0].presentationPrice.effectiveAmount,
         priceHistory: [{ date: today, price: item.prices[0].presentationPrice.effectiveAmount }],
         unit: `${item.prices[0].presentationPrice.measurementUnit.quantity} ${item.prices[0].presentationPrice.measurementUnit.unitCode}`,
-        bio: item.mixins.mpreisAttributes.properties?.includes('BIO')
+        bio: item.mixins.mpreisAttributes.properties?.includes('BIO'),
+        url: `https://www.mpreis.at/shop/p/${item.code}`
     };
 }
 

--- a/stores/spar.js
+++ b/stores/spar.js
@@ -18,7 +18,8 @@ exports.getCanonical = function(item, today) {
         price,
         priceHistory: [{ date: today, price }],
         unit,
-        bio: item.masterValues.biolevel === "Bio"
+        bio: item.masterValues.biolevel === "Bio",
+        url: `https://www.interspar.at/shop/lebensmittel${item.masterValues.url}`
     };
 }
 


### PR DESCRIPTION
- Rename eigenmarken to budgetBrands
- Split Data and UI
- Use canonicalUrls from rawData to calculate url per Item
- Refactor searchItems to use generic store syntax