### PR TITLE
Don't convert weighted articles to 100g

### DIFF
--- a/stores/utils.js
+++ b/stores/utils.js
@@ -9,11 +9,6 @@ exports.convertUnit = function (item, units, store) {
     const conv = units[item.unit];
     item.quantity = conv.factor * item.quantity;
     item.unit = conv.unit;
-
-    if (item.isWeighted && (item.unit == "g" || item.unit == "ml")) {
-        item.price = (100 * item.price) / item.quantity;
-        item.quantity = 100;
-    }
     return item;
 };
 


### PR DESCRIPTION
Issues:
- 100g feels wrong for some articles (the cheaper ones)
- priceHistory wasn't changed (so the shown prices were wrong/inconsistent with changed quantity)

Example: Billa "Da komm ich her! Apfel Tasse rot aus Österreich" (now showing 1.99 per 1000g, instead of 1.99 per 100g)