### PR TITLE
Fix quantities with "Tausendertrennpunkt" in Spar

### DIFF
--- a/stores/spar.js
+++ b/stores/spar.js
@@ -23,7 +23,7 @@ exports.getCanonical = function (item, today) {
         else if (description.endsWith("im topf")) [quantity, unit] = [1, "kg"];
         else [quantity, unit] = [1, "stk."];
     } else {
-        const s = description.replace(" EINWEG", "").replace(" MEHRWEG", "").trim();
+        const s = description.replace(" EINWEG", "").replace(" MEHRWEG", "").trim().replace(".", "");
         const q = utils.parseUnitAndQuantityAtEnd(s);
         quantity = q[0];
         unit = q[1];


### PR DESCRIPTION
Didn't dare to ignore dots globally, as I discovered stuff like "500.000 GR" in MPREIS data.

Fixes #71