### PR TITLE
Use price-per-unit field for weighted products in spar

### DIFF
--- a/stores/spar.js
+++ b/stores/spar.js
@@ -45,6 +45,12 @@ exports.getCanonical = function (item, today) {
         };
     }
 
+    const isWeighted = item.masterValues["item-type"] === "WeightProduct";
+    if (isWeighted) {
+        unit = fallback.unit;
+        quantity = fallback.quantity;
+    }
+
     return utils.convertUnit(
         {
             id: item.masterValues["code-internal"],
@@ -54,7 +60,7 @@ exports.getCanonical = function (item, today) {
             priceHistory: [{ date: today, price }],
             unit,
             quantity,
-            isWeighted: item.masterValues["item-type"] === "WeightProduct",
+            isWeighted,
             bio: item.masterValues.biolevel === "Bio",
             url: item.masterValues.url,
         },


### PR DESCRIPTION
seems more robust

This time I checked a diff of the generated data. (when I have time, I will check in a code to print all changes to a reference latest-canonical file for future updates)