### PR TITLE
Add logic for deselect item chart to hide the chart again

### DIFF
--- a/site/views/items-list.js
+++ b/site/views/items-list.js
@@ -339,6 +339,9 @@ class ItemsList extends View {
                 if (item.chart && !this.elements.enableChart.checked) {
                     this.elements.enableChart.checked = true;
                     this.elements.chart.classList.remove("hidden");
+                } else if (!item.chart && this.elements.enableChart.checked) {
+                    this.elements.enableChart.checked = false;
+                    this.elements.chart.classList.add("hidden");
                 }
                 this.elements.chart.render();
                 this._ignoreChange = true;


### PR DESCRIPTION
heyo :) thx a lot for the project

I stumbled upon the behaviour that the chart is popping up once the user selects the "chart" icon on the specific item in the list, however the chart does not correctly hide again, on deselecting the "chart" icon.

This PR aims to fix this behaviour by adding a simple else if check for the reverse logic and adding the hidden tag again to the chart.