### PR TITLE
Add Müller Austria and Müller Germany without categorization

### DIFF
--- a/site/model/stores.js
+++ b/site/model/stores.js
@@ -80,6 +80,20 @@ exports.stores = {
         defaultChecked: false,
         getUrl: (item) => `https://www.spar.si/online/p/${item.id}`,
     },
+    mueller: {
+        name: "Müller",
+        budgetBrands: ["aveo"],
+        color: "emerald",
+        defaultChecked: true,
+        getUrl: (item) => `https://www.muller.at/${item.url}`,
+    },
+    muellerDe: {
+        name: "Müller DE",
+        budgetBrands: ["aveo"],
+        color: "stone",
+        defaultChecked: false,
+        getUrl: (item) => `https://www.muller.de/${item.url}`,
+    },
 };
 
 exports.STORE_KEYS = Object.keys(exports.stores);

--- a/stores/index.js
+++ b/stores/index.js
@@ -9,3 +9,5 @@ exports.sparSi = require("./spar-si");
 exports.unimarkt = require("./unimarkt");
 exports.reweDe = require("./rewe-de");
 exports.penny = require("./penny");
+exports.mueller = require("./mueller");
+exports.muellerDe = require("./mueller-de");

--- a/stores/mueller-de.js
+++ b/stores/mueller-de.js
@@ -1,0 +1,87 @@
+const axios = require("axios");
+const utils = require("./utils");
+
+const units = {
+    wl: { unit: "wg", factor: 1 },
+    bl: { unit: "stk", factor: 1 },
+    btl: { unit: "stk", factor: 1 },
+    portion: { unit: "stk", factor: 1 },
+    satz: { unit: "stk", factor: 1 },
+    tablette: { unit: "stk", factor: 1 },
+    undefined: { unit: "stk", factor: 1 },
+};
+
+const categoriesExcludeList = ["Spielwaren", "Multi-Media", "Schreibwaren", "Strümpfe", "Handarbeit", "Bücher"];
+
+exports.getCanonical = function (item, today) {
+    let [quantity, unit] = utils.parseUnitAndQuantityAtEnd(item.unit);
+    return utils.convertUnit(
+        {
+            id: item.id,
+            name: item.name,
+            // description: "", not available
+            price: item.price,
+            priceHistory: [{ date: today, price: item.price }],
+            quantity,
+            unit,
+            bio: item.name.toLowerCase().includes("bio"),
+            url: item.canonicalUrl,
+        },
+        units,
+        "mueller"
+    );
+};
+
+function mapMullerProducts(product) {
+    return {
+        id: product.productId,
+        name: product.name,
+        price: parseFloat(product.impressionDataLayer.ecommerce.impressions[0].price),
+        unit: product.quantityOfContent,
+        canonicalUrl: product.productUrl.replace(exports.urlBase, ""),
+        category: product.impressionDataLayer.ecommerce.impressions[0].category,
+    };
+}
+
+exports.fetchData = async function () {
+    let muellerItems = [];
+
+    const MUELLER_CATEGORY_PAGES = [];
+    const data = (await axios.get(`${exports.urlBase}/ajax/burgermenu/`)).data;
+    data.forEach((category) => {
+        if (!categoriesExcludeList.includes(category.name)) {
+            const subcategories = category.subcategories.map((subcategory) => subcategory.url);
+            MUELLER_CATEGORY_PAGES.push(...subcategories);
+        }
+    });
+
+    for (let page of MUELLER_CATEGORY_PAGES) {
+        const response = await axios.get(`${page}?ajax=true&p=1`);
+        const plp = response?.data?.productlistresult;
+
+        if (plp && plp.products && plp.products.length) {
+            const plpProducts = plp.products.map(mapMullerProducts);
+            muellerItems.push(...plpProducts);
+
+            // loop throw pagination
+            // start at second page
+            let pages = plp.pager.maxPage;
+            for (let i = 2; i < pages.length; i++) {
+                const paginatedResponse = await axios.get(`${page}?ajax=true&p=1`);
+                const paginatedPlp = paginatedResponse?.data?.productlistresult;
+                if (paginatedPlp && paginatedPlp.products && paginatedPlp.products.length) {
+                    const paginatedPlpProducts = paginatedPlp.products.map(mapMullerProducts);
+                    muellerItems.push(...paginatedPlpProducts);
+                }
+            }
+        }
+    }
+
+    return muellerItems;
+};
+
+exports.initializeCategoryMapping = async () => {};
+
+exports.mapCategory = (rawItem) => {};
+
+exports.urlBase = "https://www.mueller.de";

--- a/stores/mueller.js
+++ b/stores/mueller.js
@@ -1,0 +1,87 @@
+const axios = require("axios");
+const utils = require("./utils");
+
+const units = {
+    wl: { unit: "wg", factor: 1 },
+    bl: { unit: "stk", factor: 1 },
+    btl: { unit: "stk", factor: 1 },
+    portion: { unit: "stk", factor: 1 },
+    satz: { unit: "stk", factor: 1 },
+    tablette: { unit: "stk", factor: 1 },
+    undefined: { unit: "stk", factor: 1 },
+};
+
+const categoriesExcludeList = ["Spielwaren", "Multi-Media", "Schreibwaren", "Strümpfe", "Handarbeit", "Bücher"];
+
+exports.getCanonical = function (item, today) {
+    let [quantity, unit] = utils.parseUnitAndQuantityAtEnd(item.unit);
+    return utils.convertUnit(
+        {
+            id: item.id,
+            name: item.name,
+            // description: "", not available
+            price: item.price,
+            priceHistory: [{ date: today, price: item.price }],
+            quantity,
+            unit,
+            bio: item.name.toLowerCase().includes("bio"),
+            url: item.canonicalUrl,
+        },
+        units,
+        "mueller"
+    );
+};
+
+function mapMullerProducts(product) {
+    return {
+        id: product.productId,
+        name: product.name,
+        price: parseFloat(product.impressionDataLayer.ecommerce.impressions[0].price),
+        unit: product.quantityOfContent,
+        canonicalUrl: product.productUrl.replace(exports.urlBase, ""),
+        category: product.impressionDataLayer.ecommerce.impressions[0].category,
+    };
+}
+
+exports.fetchData = async function () {
+    let muellerItems = [];
+
+    const MUELLER_CATEGORY_PAGES = [];
+    const data = (await axios.get(`${exports.urlBase}/ajax/burgermenu/`)).data;
+    data.forEach((category) => {
+        if (!categoriesExcludeList.includes(category.name)) {
+            const subcategories = category.subcategories.map((subcategory) => subcategory.url);
+            MUELLER_CATEGORY_PAGES.push(...subcategories);
+        }
+    });
+
+    for (let page of MUELLER_CATEGORY_PAGES) {
+        const response = await axios.get(`${page}?ajax=true&p=1`);
+        const plp = response?.data?.productlistresult;
+
+        if (plp && plp.products && plp.products.length) {
+            const plpProducts = plp.products.map(mapMullerProducts);
+            muellerItems.push(...plpProducts);
+
+            // loop throw pagination
+            // start at second page
+            let pages = plp.pager.maxPage;
+            for (let i = 2; i < pages.length; i++) {
+                const paginatedResponse = await axios.get(`${page}?ajax=true&p=1`);
+                const paginatedPlp = paginatedResponse?.data?.productlistresult;
+                if (paginatedPlp && paginatedPlp.products && paginatedPlp.products.length) {
+                    const paginatedPlpProducts = paginatedPlp.products.map(mapMullerProducts);
+                    muellerItems.push(...paginatedPlpProducts);
+                }
+            }
+        }
+    }
+
+    return muellerItems;
+};
+
+exports.initializeCategoryMapping = async () => {};
+
+exports.mapCategory = (rawItem) => {};
+
+exports.urlBase = "https://www.mueller.at";


### PR DESCRIPTION
* Added mueller.at and mueller.de (mueller.ch would be that easy but not euro values)
* no categorization (I can add this soon)
* excluded some categories which are non-food or non-Drogerie: "Spielwaren", "Multi-Media", "Schreibwaren", "Strümpfe", "Handarbeit", "Bücher"]
* I used some still existing colors for the store - maybe you find some better colors