### PR TITLE
Fix highlighting of keywords

### DIFF
--- a/site/views/items-list.js
+++ b/site/views/items-list.js
@@ -209,14 +209,9 @@ class ItemsList extends View {
     }
 
     highlightMatches(keywords, name) {
-        let highlightedName = name;
-        for (let i = 0; i < keywords.length; i++) {
-            const string = keywords[i];
-            // check if keyword is not preceded by a < or </
-            const regex = new RegExp(`(?<!<\/?)${string}`, "gi");
-            highlightedName = highlightedName.replace(regex, "<strong>$&</strong>");
-        }
-        return `${highlightedName}`;
+        // check if keyword is not preceded by a < or </
+        const regex = new RegExp(`(?<!<\/?)${keywords.join("|")}`, "gi");
+        return name.replace(regex, "<strong>$&</strong>");
     }
 
     renderItem(item) {


### PR DESCRIPTION
Through the iterative approach, whenever a keyword is a sub-string of "strong", it will replace all occurrences of this keyword and therefore mess up the already inserted `<strong>` tags.

The new solution lets the `replace()` call deal with that and replace keywords on the spot.

This fixes issue https://github.com/badlogic/heissepreise/issues/132