### PR TITLE
replace 💀 with † to be more clear on what it means

### DIFF
--- a/site/views/items-list.js
+++ b/site/views/items-list.js
@@ -331,7 +331,7 @@ class ItemsList extends View {
         const elements = View.elements(itemDom);
         elements.store.innerText = item.store;
         elements.name.href = stores[item.store].getUrl(item);
-        elements.name.innerHTML = this.highlightMatches(this.model.lastQueryTokens ?? [], item.name) + (item.unavailable ? " 💀" : "");
+        elements.name.innerHTML = this.highlightMatches(this.model.lastQueryTokens ?? [], item.name) + (item.unavailable ? " †" : "");
         elements.quantity.innerText = (item.isWeighted ? "⚖ " : "") + `${quantity} ${unit}`;
         elements.price.innerText = `€ ${Number(showUnitPrice ? unitPrice : price).toFixed(2)} ${priceUnit}`;
         elements.priceHistory.innerHTML = priceHistory;


### PR DESCRIPTION
When I first saw "Kochschokolade Bella 400g 💀" I laughed my ass off, trying to find out what it meant. Out of stock - well, I figured, the symbol many others use for deceased people and species extinction would be more clear.

on an unrelated note, this symbol has the unicode code [U+2020](https://en.wikipedia.org/wiki/Dagger_(mark)), which is kind of creepy, seeing as it was [added in unicode 1.1](https://www.unicode.org/Public/1.1-Update/UnicodeData-1.1.5.txt), so, 1993. idk, odd coincidence I guess.