### PR TITLE
initial Aldi Germany support

### DIFF
--- a/site/model/stores.js
+++ b/site/model/stores.js
@@ -102,6 +102,13 @@ exports.stores = {
         defaultChecked: false,
         getUrl: (item) => `https://www.muller.de/${item.url}`,
     },
+    aldiDe: {
+        name: "Aldi DE",
+        budgetBrands: ["milsana"],
+        color: "lime",
+        defaultChecked: true,
+        getUrl: (item) => `https://www.mein-aldi.de/product/${item.url}`,
+    },
 };
 
 exports.STORE_KEYS = Object.keys(exports.stores);

--- a/site/style.css
+++ b/site/style.css
@@ -117,6 +117,10 @@ thead > tr {
     @apply bg-emerald-600/50;
     @apply border-emerald-500;
 }
+.item.lime {
+    @apply bg-lime-200/50;
+    @apply border-lime-200;
+}
 
 /* checkbox */
 .customcheckbox {
@@ -191,6 +195,11 @@ thead > tr {
     @apply bg-indigo-200;
     @apply border-indigo-300;
     @apply hover:bg-indigo-300;
+}
+.customcheckbox.lime {
+    @apply bg-lime-200;
+    @apply border-lime-300;
+    @apply hover:bg-lime-300;
 }
 
 /* items filter */

--- a/stores/aldi-de.js
+++ b/stores/aldi-de.js
@@ -1,0 +1,56 @@
+const fs = require("fs");
+const path = require("path");
+const axios = require("axios");
+const utils = require("./utils");
+
+const units = {};
+
+exports.getCanonical = function (item, today) {
+    let quantity = 1;
+    let unit = "stk";
+    if (item.preFormattedUnitContent) {
+        [quantity, unit] = utils.parseUnitAndQuantityAtEnd(item.preFormattedUnitContent);
+    }
+    return utils.convertUnit(
+        {
+            id: item.productConcreteSku,
+            name: item.name,
+            // description: "", not available
+            price: item.prices[0].grossAmount / 100,
+            priceHistory: [{ date: today, price: item.prices[0].grossAmount / 100 }],
+            isWeighted: false,
+            unit,
+            quantity,
+            bio: item.name.toLowerCase().includes("bio"),
+            url: `${item.urlSlugText}-${item.productConcreteSku}`,
+        },
+        units,
+        "aldiDe",
+        {
+            quantity: 1,
+            unit: "stk",
+        }
+    );
+};
+
+exports.fetchData = async function () {
+    offset = 0;
+    items = [];
+    done = false;
+    while (!done) {
+        const ALDI_ITEM_SEARCH = `https://api.de.prod.commerce.ci-aldi.com/v1/catalog-search-product-offers?page[limit]=48&page[offset]=${offset}&merchantReference=ADG045_1`;
+        resp = (await axios.get(ALDI_ITEM_SEARCH)).data;
+        maxpage = resp.data[0].attributes.pagination.maxPage;
+        currentpage = resp.data[0].attributes.pagination.currentPage;
+        done = offset > 5000 || currentpage >= maxpage;
+        items = items.concat(resp.data[0].attributes.catalogSearchProductOfferResults);
+        offset += 48;
+    }
+    return items;
+};
+
+exports.urlBase = "https://www.mein-aldi.de/product/";
+
+exports.initializeCategoryMapping = async () => {};
+
+exports.mapCategory = (rawItem) => {};

--- a/stores/index.js
+++ b/stores/index.js
@@ -2,6 +2,7 @@ exports.billa = require("./billa");
 exports.dm = require("./dm");
 exports.dmDe = require("./dm-de");
 exports.hofer = require("./hofer");
+exports.aldiDe = require("./aldi-de");
 exports.lidl = require("./lidl");
 exports.mpreis = require("./mpreis");
 exports.spar = require("./spar");


### PR DESCRIPTION
Thanks for your nice price crawler! I added initial support for Aldi Germany.

- Retrieves Aldi Germany prices via "https://www.mein-aldi.de"
- Seems to match the "https://aldi-sued.de"
- No support for categories
- Some units are not correct, e.g. "Weihenstephan H-Milch" or "Lacura Flüssigseife" (Stk. instead of Liter)
- Some quantities are not correct, e.g. "Activ Energy Batterien" does not identify 8 batteries