### PR TITLE
Fix search placeholder locale variable

### DIFF
--- a/site/cart.html
+++ b/site/cart.html
@@ -16,7 +16,7 @@
         stores
         misc
         nochartclear
-        placeholder="__Produkt hinzufügen...__ (__min. 3 Zeichen__)"
+        placeholder="__Produkt hinzufügen...__ __(min. 3 Zeichen)__"
     ></items-filter>
     <items-list x-id="productsList" class="hidden" add></items-list>
     %%_templates/_loader.html%%


### PR DESCRIPTION
Fixes usage of the (min. 3 Zeichen) locale string so it is presented correctly in the search box placeholder.