### PR TITLE
fix DM (AT & DE)

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -12,8 +12,7 @@
     <div class="text-xs p-2 text-center">
         Achtung<br />
         Folgende Stores werden nicht mehr aktualisiert: Rewe Deutschland (15.2.2024), Unimarkt (24.2.2024), Bipa (4.4.2024), MPreis (24.6.2024),
-        Müller (3.3.2025), Müller Deutschland (3.3.2025), Lidl (27.3.2025), DM (29.7.2025), DM Deutschland (29.7.2025), Penny (14.10.2025), Hofer
-        (10.11.2025)<br />
+        Müller (3.3.2025), Müller Deutschland (3.3.2025), Lidl (27.3.2025), Penny (14.10.2025), Hofer (10.11.2025)<br />
         Die historischen Daten sind weiterhin verfügbar.
     </div>
     <items-filter x-id="items-filter" emptyquery stores misc></items-filter>

--- a/stores/dm-de.js
+++ b/stores/dm-de.js
@@ -8,6 +8,7 @@ const units = {
     portion: { unit: "stk", factor: 1 },
     satz: { unit: "stk", factor: 1 },
     tablette: { unit: "stk", factor: 1 },
+    undefined: { unit: "stk", factor: 1 },
 };
 
 exports.getCanonical = function (item, today) {
@@ -16,8 +17,20 @@ exports.getCanonical = function (item, today) {
         return null;
     }
 
-    let quantity = item.netQuantityContent || item.basePriceQuantity;
-    let unit = item.contentUnit || item.basePriceUnit;
+    let quantityToParse;
+    if (item.tileData.price?.tileInfos) {
+        const tileInfos = item.tileData.price.tileInfos[item.tileData.price?.tileInfos.length - 1].replaceAll(" ", "").split(" ");
+        quantityToParse = tileInfos[0] + " " + tileInfos[1];
+    } else {
+        const regex = /^([0-9.,]+)\s(.*)$/;
+        const titleParts = item.title.replaceAll(" ", "").split(", ");
+        const titleSuffix = titleParts[titleParts.length - 1];
+        if (titleSuffix.match(regex)) {
+            quantityToParse = titleSuffix;
+        }
+    }
+
+    let [quantity, unit] = utils.parseUnitAndQuantityAtEnd(quantityToParse);
     return utils.convertUnit(
         {
             id: String(item.gtin),

--- a/stores/dm-de.js
+++ b/stores/dm-de.js
@@ -12,7 +12,7 @@ const units = {
 
 exports.getCanonical = function (item, today) {
     // Skip items without price
-    if (!item.price || !item.price.value) {
+    if (!item.tileData?.trackingData?.price) {
         return null;
     }
 
@@ -23,8 +23,8 @@ exports.getCanonical = function (item, today) {
             id: String(item.gtin),
             name: `${item.brandName} ${item.title}`,
             // description: "", not available
-            price: item.price.value,
-            priceHistory: [{ date: today, price: item.price.value }],
+            price: item.tileData.trackingData.price,
+            priceHistory: [{ date: today, price: item.tileData.trackingData.price }],
             unit,
             quantity,
             ...((item.brandName === "dmBio" || (item.name ? item.name.startsWith("Bio ") | item.name.startsWith("Bio-") : false)) && { bio: true }),
@@ -42,7 +42,8 @@ exports.fetchData = async function () {
         "allCategories.id=010000&price.value.from=3&price.value.to=4", //~500 items
         "allCategories.id=010000&price.value.from=4&price.value.to=6", //~800 items
         "allCategories.id=010000&price.value.from=6&price.value.to=8", //~800 items
-        "allCategories.id=010000&price.value.from=8&price.value.to=10", //~900 items
+        "allCategories.id=010000&price.value.from=8&price.value.to=9", //~500 items
+        "allCategories.id=010000&price.value.from=9&price.value.to=10", //~700 items
         "allCategories.id=010000&price.value.from=10&price.value.to=14", //~900 items
         "allCategories.id=010000&price.value.from=14", //~300 items
         "allCategories.id=020000&price.value.to=2", //~600 items
@@ -52,8 +53,8 @@ exports.fetchData = async function () {
         "allCategories.id=020000&price.value.from=6&price.value.to=10", //~850 items
         "allCategories.id=020000&price.value.from=10&price.value.to=18", //~900 items
         "allCategories.id=020000&price.value.from=18", //~960 items (!)
-        "allCategories.id=030000&price.value.to=7", //~980 items (!)
-        "allCategories.id=030000&price.value.from=7", //~500 items
+        "allCategories.id=030000&price.value.to=5.5", //~850 items
+        "allCategories.id=030000&price.value.from=5.5", //~980 items
         "allCategories.id=040000&price.value.to=2", //~600 items
         "allCategories.id=040000&price.value.from=2&price.value.to=4", //~900 items
         "allCategories.id=040000&price.value.from=4", //~400 items
@@ -93,7 +94,7 @@ exports.fetchData = async function () {
             );
         }
         dmItems = dmItems.concat(items.products);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
+        await new Promise((resolve) => setTimeout(resolve, 2000));
     }
     return dmItems;
 };

--- a/stores/dm.js
+++ b/stores/dm.js
@@ -13,7 +13,7 @@ const units = {
 
 exports.getCanonical = function (item, today) {
     // Skip items without price
-    if (!item.price || !item.price.value) {
+    if (!item.tileData?.trackingData?.price) {
         return null;
     }
 
@@ -24,8 +24,8 @@ exports.getCanonical = function (item, today) {
             id: "" + item.gtin,
             name: `${item.brandName} ${item.title}`,
             // description: "", not available
-            price: item.price.value,
-            priceHistory: [{ date: today, price: item.price.value }],
+            price: item.tileData.trackingData.price,
+            priceHistory: [{ date: today, price: item.tileData.trackingData.price }],
             unit,
             quantity,
             ...((item.brandName === "dmBio" || (item.name && /^Bio[ -]/.test(item.name))) && { bio: true }),
@@ -43,8 +43,8 @@ exports.fetchData = async function () {
         "allCategories.id=010000&price.value.from=3&price.value.to=4", //~500 items
         "allCategories.id=010000&price.value.from=4&price.value.to=7", //~800 items
         "allCategories.id=010000&price.value.from=7&price.value.to=10", //~900 items
-        "allCategories.id=010000&price.value.from=10&price.value.to=15", //~900 items
-        "allCategories.id=010000&price.value.from=15", //~300 items
+        "allCategories.id=010000&price.value.from=10&price.value.to=14", //~800 items
+        "allCategories.id=010000&price.value.from=14", //~500 items
         "allCategories.id=020000&price.value.to=2", //~600 items
         "allCategories.id=020000&price.value.from=2&price.value.to=3", //~550 items
         "allCategories.id=020000&price.value.from=3&price.value.to=4", //~600 items
@@ -53,8 +53,8 @@ exports.fetchData = async function () {
         "allCategories.id=020000&price.value.from=10&price.value.to=18", //~930 items
         "allCategories.id=020000&price.value.from=18&price.value.to=70", //~940 items
         "allCategories.id=020000&price.value.from=70", //~60 items
-        "allCategories.id=030000&price.value.to=8", //~900 items
-        "allCategories.id=030000&price.value.from=8", //~500 items
+        "allCategories.id=030000&price.value.to=7", //~850 items
+        "allCategories.id=030000&price.value.from=7", //~650 items
         "allCategories.id=040000&price.value.to=2", //~600 items
         "allCategories.id=040000&price.value.from=2&price.value.to=4", //~900 items
         "allCategories.id=040000&price.value.from=4", //~400 items
@@ -92,7 +92,7 @@ exports.fetchData = async function () {
             );
         }
         dmItems = dmItems.concat(items.products);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
+        await new Promise((resolve) => setTimeout(resolve, 2000));
     }
     return dmItems;
 };

--- a/stores/dm.js
+++ b/stores/dm.js
@@ -17,8 +17,20 @@ exports.getCanonical = function (item, today) {
         return null;
     }
 
-    let quantity = item.netQuantityContent || item.basePriceQuantity;
-    let unit = item.contentUnit || item.basePriceUnit;
+    let quantityToParse;
+    if (item.tileData.price?.tileInfos) {
+        const tileInfos = item.tileData.price.tileInfos[item.tileData.price?.tileInfos.length - 1].replaceAll(" ", "").split(" ");
+        quantityToParse = tileInfos[0] + " " + tileInfos[1];
+    } else {
+        const regex = /^([0-9.,]+)\s(.*)$/;
+        const titleParts = item.title.replaceAll(" ", "").split(", ");
+        const titleSuffix = titleParts[titleParts.length - 1];
+        if (titleSuffix.match(regex)) {
+            quantityToParse = titleSuffix;
+        }
+    }
+
+    let [quantity, unit] = utils.parseUnitAndQuantityAtEnd(quantityToParse);
     return utils.convertUnit(
         {
             id: "" + item.gtin,


### PR DESCRIPTION
DM API has changed (price moved somewhere else, unit & quantity fields disappeared, we need to parse them from other fields).
Ugly, but works again.

Also, waiting for 2 seconds instead of 1 between API calls seems to pretty much eliminate the need for the backoff, I don't get any 429s anymore. Still keeping the backoff for now.